### PR TITLE
Move import of coin into function

### DIFF
--- a/README
+++ b/README
@@ -39,19 +39,34 @@ Open-source python magic happens: if you want to do something, you can do it.
 Installation
 ------------
 LINUX:
-To install Tracer on your system, run the following from the command line from your downloaded Tracer directory:
+Tested under Ubuntu 22 (running as WSL)
 
-  python3 setup.py install
+1) Prepare Linux: sudo apt update && sudo apt upgrade
+2) Setup python environment
+2.1) sudo apt install python3-venv
+2.2) Create virtual environment: python3 -m venv .venv
+2.3) Activate virtual environment: source ./.venv/bin/activate
 
-Before installing, make sure that the following dependencies are installed:
-- Numpy/Scipy (http://www.scipy.org/scipylib/download.html)
-  command: sudo apt install python-numpy
+3) (Optional) Install visualisation-dependencies (not required if running headless)
+3.1) Install build dependencies: sudo apt install build-essential cmake
+3.2) Install coin3d dependencies: sudo apt install libboost-all-dev xorg-dev libglu1-mesa-dev
+3.3) Install coin3d
+3.3.1) git clone --recurse-submodules https://github.com/coin3d/coin coin
+3.3.2) sudo cmake -Hcoin -Bcoin_build -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCOIN_BUILD_DOCUMENTATION=OFF
+3.3.3) sudo cmake --build coin_build --target all --config Release -- -j4
+3.3.4) sudo cmake --build coin_build --target install --config Release -- -j4
+3.4) Install pivy: sudo apt install python3-pivy
+3.5) Allow access to global pivy package:
+3.5.1) nano ./.venv/pyvenv.cfg
+3.5.2) Change: 'include-system-site-packages = false' to 'include-system-site-packages = true'
 
-- Matplotlib (http://matplotlib.org/downloads.html)
-  command: sudo apt install python-matplotlib
+4) Clone Tracer repository
+git clone https://github.com/casselineau/Tracer
 
-- Coin 3D (https://bitbucket.org/Coin3D/coin/downloads)
-  command: sudo pip3 install pivy
+5) Install python requirements from Tracer
+5.1) Headless: pip install -r requirements_headless.txt
+5.2) With visualisation: pip install -r requirements.txt
+
 
 WINDOWS:
 To run on MS Windows:

--- a/README
+++ b/README
@@ -23,9 +23,10 @@ library. NO GUI yet.
 DISCLAIMER: The documentation and installation is outdated, but he project is active! Doubts, need advice?: charlesalexis.asselineau@ump.es
 
 Current capablilities:
-- Flat, parabolic, spherical and conical surfaces
+- Flat, parabolic, spherical, conical and quadric surfaces
 - Specular and diffuse reflections with surface slope error
 - BDRF
+- Transparency and attenuation
 - A bunch of results analysis tools
 - Pillbox and Buie sunshape implementations
 - Radiosity sytem solver for thermal emissions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+matplotlib

--- a/requirements_headless.txt
+++ b/requirements_headless.txt
@@ -1,0 +1,2 @@
+numpy
+scipy

--- a/tracer/assembly.py
+++ b/tracer/assembly.py
@@ -2,7 +2,6 @@
 
 import operator
 import numpy as N
-from pivy import coin
 
 from tracer.spatial_geometry import general_axis_rotation
 from tracer.has_frame import HasFrame
@@ -149,6 +148,7 @@ class Assembly(HasFrame):
 			s.get_optics_manager().reset()
 
 	def get_scene_graph(self,resolution, fluxmap, trans, vmin, vmax, bounding_boxes):
+		from pivy import coin
 		n0 = coin.SoSeparator()
 		n = self.get_scene_graph_transform()
 

--- a/tracer/assembly.py
+++ b/tracer/assembly.py
@@ -73,7 +73,9 @@ class Assembly(HasFrame):
 		them, and the objects are guarantied to be ordered the same as in 
 		self.get_objects()
 		"""
-		return N.ravel([obj.get_surfaces() for obj in self.get_objects()])
+		surfaces = [surface for obj in self.get_objects() for surface in obj.get_surfaces()]
+		#surface = N.ravel([obj.get_surfaces() for obj in self.get_objects()])
+		return surfaces
 
 	def add_object(self, object, transform=None):
 		"""

--- a/tracer/geometry_manager.py
+++ b/tracer/geometry_manager.py
@@ -4,7 +4,6 @@
 # TODO: explore abstract meta-classes in Python.
 
 import numpy as N
-import pivy.coin as coin
 
 class GeometryManager(object):
 	def find_intersections(self, frame, ray_bundle):

--- a/tracer/has_frame.py
+++ b/tracer/has_frame.py
@@ -1,7 +1,6 @@
 # Represents an object that is locatable in 3D space with 6 degrees of freedom.
 
 import numpy as N
-import pivy.coin as coin
 
 class HasFrame(object):
     """
@@ -80,6 +79,8 @@ class HasFrame(object):
         Create the Coin3D transform to translate and rotate this frame, in
         accordance with the self._rot and self._loc matrices held in this class.
         """
+        import pivy.coin as coin
+        
         n = coin.SoSeparator()
         if N.any(self._loc != N.array((0,0,0))):
             tr = coin.SoTranslation()

--- a/tracer/object.py
+++ b/tracer/object.py
@@ -3,7 +3,6 @@
 import numpy as N
 from tracer.spatial_geometry import general_axis_rotation
 from tracer.assembly import Assembly
-from pivy import coin
 
 class AssembledObject(Assembly):
 	""" Defines an assembly of surfaces as an object. The object has its own set of 

--- a/tracer/optics_callables.py
+++ b/tracer/optics_callables.py
@@ -6,7 +6,7 @@ from . import optics, ray_bundle, sources
 from .spatial_geometry import rotation_to_z
 import numpy as N
 from scipy.interpolate import RegularGridInterpolator
-from BDRF_models import Cook_Torrance, regular_grid_Cook_Torrance
+#from BDRF_models import Cook_Torrance, regular_grid_Cook_Torrance
 from tracer.ray_bundle import RayBundle
 from ray_trace_utils.sampling import BDRF_distribution
 from ray_trace_utils.vector_manipulations import get_angle
@@ -515,7 +515,50 @@ class LambertianSpecular(optics_callable):
 			direction=directs, 
 			parents=selector)
 		return outg
-	#'''
+        
+
+class LambertianSpecular_IAM(optics_callable):
+	"""
+	Represents the optics of surface with mixed specular and diffuse characteristics. Specularity is the ratio of incident rays that are specularly reflected to the total number of rays incident on the surface.
+	"""
+	def __init__(self, absorptivity=0., specularity=0.5, a_r=0.16):
+		self._abs = absorptivity
+		self.specularity = specularity
+		self.a_r = a_r
+	
+	def __call__(self, geometry, rays, selector):
+		"""
+		Arguments:
+		geometry - a GeometryManager which knows about surface normals, hit
+			points etc.
+		rays - the incoming ray bundle (all of it, not just rays hitting this
+			surface)
+		selector - indices into ``rays`` of the hitting rays.
+		"""
+		in_directs = rays.get_directions()[:,selector]
+		normals = geometry.get_normals()
+		directs = N.zeros(in_directs.shape)
+		vertical = N.sum(directs*normals, axis=0)*normals
+		cos_theta_AOI = N.sqrt(N.sum(vertical**2, axis=0))
+
+		specular = N.random.rand(len(selector))<self.specularity
+
+		directs[:,specular] = optics.reflections(in_directs[:,specular], normals[:,specular])
+		direct_lamb = sources.pillbox_sunshape_directions(N.sum(~specular), ang_range=N.pi/2.)
+		directs[:,~specular] = N.sum(rotation_to_z(normals[:,~specular].T) * direct_lamb.T[:,None,:], axis=2).T
+
+		outg = rays.inherit(selector,
+			vertices=geometry.get_intersection_points_global(),
+			energy=rays.get_energy()[selector]*(1. - self._abs*(1.-N.exp(-cos_theta_AOI/self.a_r))/(1.-N.exp(-1./self.a_r))),
+			direction=directs, 
+			parents=selector)
+            
+		if outg.has_property('spectra'):
+			outg._spectra *= (1. - self._abs*(1.-N.exp(-cos_theta_AOI/self.a_r))/(1.-N.exp(-1./self.a_r)))   
+         
+		return outg
+
+
 class BDRF_Cook_Torrance_isotropic(optics_callable):
 	'''
 	Implements the Cook Torrance BDRF model using linear interpolationsand isotropic assumption

--- a/tracer/sources.py
+++ b/tracer/sources.py
@@ -40,7 +40,8 @@ def isotropic_directions_sampling(num_rays, ang_range, normals=None):
 	xi2 = random.uniform(size=num_rays) # Rtheta
 	sinsqrt = N.sin(ang_range)*N.sqrt(xi2)
 	dirs = N.vstack((N.cos(xi1)*sinsqrt, N.sin(xi1)*sinsqrt , N.sqrt(1.-sinsqrt**2.)))
-	dirs = rotate_z_to_normals(dirs, normals)
+	if normals is not None:
+		dirs = rotate_z_to_normals(dirs, normals)
 	return dirs
 
 def pillbox_sunshape_directions(num_rays, ang_range):

--- a/tracer/sphere_surface.py
+++ b/tracer/sphere_surface.py
@@ -5,7 +5,6 @@
 
 import numpy as N
 from .quadric import QuadricGM
-import pivy.coin as coin
 
 class SphericalGM(QuadricGM):
     """

--- a/tracer/trace_tree.py
+++ b/tracer/trace_tree.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-class RayTree(object):
+class RayTree:
     def __init__(self):
         self._bunds = []
         
@@ -45,14 +45,15 @@ class RayTree(object):
         if level is None:
             level = self.num_bunds()
         
-        parents = np.empty(level)
+        parents = np.empty(level, dtype=int)
         parents[0] = ray_index
         
-        for pix in xrange(1, level):
+        for pix in range(1, level):
             parents[pix] = \
-                self._bunds[level - pix + 1].get_parents()[parents[pix - 1]]
+                self._bunds[level - pix].get_parents()[parents[pix - 1]]
         
         return parents
+
 
 
 # vim: et:ts=4

--- a/tracer/tracer_engine.py
+++ b/tracer/tracer_engine.py
@@ -42,7 +42,7 @@ class TracerEngine():
 		ret_shape = (nsurfs, nrays)
 		rays_mins = N.ones(nrays)*N.inf
 		earlier_hit = N.zeros(nrays, dtype=N.bool)
-		earliest_surf = -1*N.ones(nrays, dtype=N.int)
+		earliest_surf = -1*N.ones(nrays, dtype=int)
 		surf_stack = N.zeros(nrays)
 
 		# Bounce rays off each object
@@ -88,7 +88,7 @@ class TracerEngine():
 		owned_rays = N.empty(ret_shape, dtype=N.bool)
 		rays_mins = N.ones(nrays)*N.inf
 		earlier_hit = N.zeros(nrays, dtype=N.bool)
-		earliest_surf = -1*N.ones(nrays, dtype=N.int)
+		earliest_surf = -1*N.ones(nrays, dtype=int)
 		surf_stack = N.zeros(nrays)
 
 		# Bounce rays off each object
@@ -135,7 +135,7 @@ class TracerEngine():
 		ret_shape = (nsurfs, nrays)
 		owned_rays = N.empty(ret_shape, dtype=N.bool)
 		rays_mins = N.ones(nrays)*N.inf
-		earliest_surf = -1*N.ones(nrays, dtype=N.int)
+		earliest_surf = -1*N.ones(nrays, dtype=int)
 		latest_order = N.amax(surf_relevancy, axis=0)
 		# Bounce rays off each object
 		for surf_num in range(len(surfaces)):

--- a/tracer/tracer_engine.py
+++ b/tracer/tracer_engine.py
@@ -6,6 +6,7 @@ from tracer.trace_tree import RayTree
 from tracer.accel_tree import KdTree
 import gc
 import time
+import logging
 
 class TracerEngine():
 	"""
@@ -304,10 +305,11 @@ class TracerEngine():
 					weak_ray_pos = N.hstack(weak_ray_pos)
 					record = bund + record.inherit(N.nonzero(weak_ray_pos)[0])
 					self.tree.append(record)
-				gc.collect() # This was found useful to avoid memory error when using large bundles and/or broadband sources.
+				#gc.collect() # This was found useful to avoid memory error when using large bundles and/or broadband sources.
+                # This is not useful in Python3
 			if bund.get_num_rays() == 0:
 				# All rays escaping
-				print('Ray bundle depleted')
+				logging.debug('Ray bundle depleted')
 				break
 
 			t1 = time.time()-t0
@@ -315,15 +317,15 @@ class TracerEngine():
 				ray_ownership = N.hstack(out_ray_own)
 				surfs_relevancy = N.hstack(new_surfs_relevancy)
 			else:
-				print('trace time %s s' %t1)
+				logging.debug('trace time %s s' %t1)
 
 		if not tree:
 			# Save only the last bundle. Don't bother moving weak rays to end.
 			record = concatenate_rays(record)
 			self.tree.append(record)
 		if bund.get_num_rays() != 0:
-			print (bund.get_num_rays(), 'rays left at the end of the simulation')
-			print('Remaining energy in last bundle:', N.sum(bund.get_energy())/N.sum(bundle.get_energy())*100., '%')
+			logging.warning(bund.get_num_rays(), 'rays left at the end of the simulation')
+			logging.warning('Remaining energy in last bundle:', N.sum(bund.get_energy())/N.sum(bundle.get_energy())*100., '%')
 		return bund.get_vertices(), bund.get_directions()
 
 


### PR DESCRIPTION
Move the import of the coin module to the visualisation function, to simplify dependencies when using Tracer on a 'headless' environment.