### PR TITLE
Add optical material from file, and several bug fixes

### DIFF
--- a/ray_trace_utils/optical_constants.py
+++ b/ray_trace_utils/optical_constants.py
@@ -112,13 +112,41 @@ class Al2O3(optical_material):
 		'''
 		return self.m_func(lambdas)
 
+
+class OpticalMaterialFromFile(optical_material):
+	def __init__(self, filename, wavelength_col=0, n_col=1, k_col=2, wavelength_unit='nm'):
+		data = N.loadtxt(filename, skiprows=1, delimiter=',', usecols=(wavelength_col, n_col, k_col))
+
+		unit_factor = 1
+		if wavelength_unit == 'nm':
+			unit_factor = 1e-9
+		elif wavelength_unit == 'um':
+			unit_factor = 1e-6
+		elif wavelength_unit == 'm':
+			unit_factor = 1
+		else:
+			raise ValueError("Invalid wavelength unit. Use 'nm', 'um', or 'm'.")
+
+		lambdas, m = data[:,0]*unit_factor, data[:,1] + 1j*data[:,2]
+		l_min, l_max = N.amin(lambdas), N.amax(lambdas)
+		self.m_func = interp1d(lambdas, m)
+		optical_material.__init__(self, l_min, l_max)
+
+	@optical_material.check_valid
+	def m(self, lambdas):
+		'''
+		Optical constants used by the optical manager in tracer
+		'''
+		return self.m_func(lambdas)
+
+
 class Air(optical_material):
 
 	def __init__(self):
 		# simplified air/vaccum placeholder returning 1.
 		optical_material.__init__(self, 200e-9, 10e-6)
 
-	def m(self, lambdas):
+	def m(self, lambdas=None):
 		'''
 		Optical constants used by the optical manager in tracer
 		'''

--- a/tracer/accel_tree.py
+++ b/tracer/accel_tree.py
@@ -222,19 +222,19 @@ class KdTree(object):
 
 		bounds = N.array([self.minpoint, self.maxpoint])
 		inters, t_mins, t_maxs = self.intersect_bounds(poss, dirs, inv_dirs, bounds)
+		any_inter = False
+		if lightweight:
+			#surfaces_relevancy = [[self.always_relevant] for _ in range(nrays)]
+			surfaces_relevancy = [[[]] for _ in range(self.n_surfs)]
+			ray_orders = N.zeros(nrays, dtype=int)
+			for s in self.always_relevant:
+				surfaces_relevancy[s] += [r for r in range(nrays)]
+		else:
+			surfaces_relevancy = N.zeros((self.n_surfs, nrays), dtype=bool)
+			surfaces_relevancy[self.always_relevant] = True
 
 		if inters.any():
 			n_inters = len(inters)
-			any_inter = False
-			if lightweight:
-				#surfaces_relevancy = [[self.always_relevant] for _ in range(nrays)]
-				surfaces_relevancy = [[[]] for _ in range(self.n_surfs)]
-				ray_orders = N.zeros(nrays, dtype=int)
-				for s in self.always_relevant:
-					surface_relevancy[s] += [r for r in range(nrays)]
-			else:
-				surfaces_relevancy = N.zeros((self.n_surfs, nrays), dtype=bool)
-				surfaces_relevancy[self.always_relevant] = True
 			# for rays that do intersect, go down the tree (or up?):
 			for r in range(n_inters):
 				if inters[r] == False:

--- a/tracer/ray_bundle.py
+++ b/tracer/ray_bundle.py
@@ -98,8 +98,8 @@ class RayBundle:
 			types.MethodType(setter, self)
 		
 		if init_val is not None:
-	   		self.__dict__['set_' + propname](init_val)
-	
+			self.__dict__['set_' + propname](init_val)
+
 	def has_property(self, propname):
 		"""
 		Checks whether the looked-after property ``propname`` exists for this

--- a/tracer/sources.py
+++ b/tracer/sources.py
@@ -219,7 +219,7 @@ def rect_bundle(num_rays, center, direction, x, y, ang_range, flux=None, procs=1
 
 #def bivariate_rect_bundle(num_rays, center, direction, x, y, ang_range_vert, ang_range_hor, flux=None):
 
-def oblique_solar_rect_bundle(num_rays, center, source_direction, rays_direction, x, y, ang_range, flux=None, procs=1, wavelength=None):
+def oblique_solar_rect_bundle(num_rays, center, source_direction, rays_direction, x, y, ang_range, flux=None, procs=1, wavelength=None, ref_index=None):
 	a = pillbox_sunshape_directions(num_rays, ang_range)
 	# Rotate to a frame in which <direction> is Z:
 	perp_rot = rotation_to_z(rays_direction)
@@ -246,6 +246,13 @@ def oblique_solar_rect_bundle(num_rays, center, source_direction, rays_direction
 		rayb.set_energy(x*y/num_rays*flux*N.ones(num_rays)*N.cos(cosangle))
 	else:
 		rayb.set_energy(N.ones(num_rays)/float(num_rays)/procs)
+
+	if wavelength is not None:
+		rayb._create_property('wavelengths', N.ones(num_rays)*wavelength)
+	
+	if ref_index is not None:
+		rayb._create_property('ref_index', N.ones(num_rays)*ref_index)
+
 	return rayb
 
 def edge_rays_bundle(num_rays,  center,  direction,  radius, ang_range, flux=None, radius_in=0.):


### PR DESCRIPTION
- Add class OpticalMaterialFromFile to ray_trace_utils/optical_constants.py: This new class enables loading arbitrary csv files as optical material
- Fix a potential NameError in accel_tree.py: Output variables any_inter and surfaces_relevancy not defined when inters.any() is False
- Fix indentation error in ray_bundle.py
- Add wavelengths and ref_index property to oblique_solar_rect_bundle.py